### PR TITLE
fix: build Minecraft container image for linux/amd64

### DIFF
--- a/lib/game-demo-fargate-docker-stack.ts
+++ b/lib/game-demo-fargate-docker-stack.ts
@@ -3,6 +3,7 @@ import ec2 = require('aws-cdk-lib/aws-ec2');
 import ecs = require('aws-cdk-lib/aws-ecs');
 import logs = require('aws-cdk-lib/aws-logs');
 import ecs_patterns = require('aws-cdk-lib/aws-ecs-patterns');
+import ecr_assets = require('aws-cdk-lib/aws-ecr-assets');
 import cdk = require('aws-cdk-lib');
 import path = require('path');
 
@@ -29,7 +30,9 @@ export class GameDemoFargateDockerStack extends cdk.Stack {
       // Create the container image and store it in Elastic Container Registry (ECR). 
       // CDK will manage the creation and upload of the container image,
       // just add the folder path name to the .Docker file to be used as the container image.
-      image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'minecraft-image')),
+      image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'minecraft-image'), {
+        platform: ecr_assets.Platform.LINUX_AMD64,
+      }),
       environment: {
         EULA: 'TRUE',
         VERSION: 'LATEST',


### PR DESCRIPTION
## Summary
Pin the Fargate container asset to `linux/amd64` so locally-built images run on the default X86_64 Fargate runtime.

## Problem
`ContainerImage.fromAsset(...)` builds for the **host** architecture. Building on Apple Silicon (arm64) produces an arm64 image, which crash-loops on default Fargate (X86_64) with:
```
exec /usr/bin/java: exec format error
```
This doesn't surface in the CodeBuild pipeline (x86 Linux) but breaks any local `cdk deploy`.

## Change
```ts
image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, 'minecraft-image'), {
  platform: ecr_assets.Platform.LINUX_AMD64,
}),
```

## Testing
Deployed the Fargate stack to a test account: task reached RUNNING, Minecraft 1.20.4 logged `Done` and was reachable on TCP 25565. Resources torn down after validation.