### PR TITLE
feat: resolve deploy account/region from active profile for local deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Update a few values in the sample code before deploying.
 
 Open the cdk.context.json file and update the 3 values based on your environment:
 -	default_repo_branch_name – The name of your AWS CodeCommit repository branch
--	dev_account_id – The AWS account ID where you want to deploy the game server
+-	dev_account_id – The AWS account ID where you want to deploy the game server. Optional: if omitted, deploys fall back to the account of the active AWS CLI profile/credentials (useful for local single-account deploys). Set it explicitly for cross-account pipeline deployments.
 -	deployment_region – The AWS region where you want to deploy the game server
     - If you change the region from us-west-2 you will also need to update the region in the bin/game-demo-pipeline.ts file and change the region in command line parameters in later steps
 

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -1,5 +1,4 @@
 {
   "default_repo_branch_name": "main",
-  "dev_account_id": "DevAccountId",
   "deployment_region": "us-west-2"
 }

--- a/lib/game-demo-pipeline-stack.ts
+++ b/lib/game-demo-pipeline-stack.ts
@@ -30,9 +30,10 @@ export class GameDemoPipelineStack extends cdk.Stack {
       })
     });
 
-    // Gets the account id and deployment region from the configuration file.
-    const devAccountId = this.node.tryGetContext('dev_account_id');
-    const deploymentRegion = this.node.tryGetContext('deployment_region');
+    // Gets the account id and deployment region from the configuration file,
+    // falling back to the active CLI/profile account & region for local deploys.
+    const devAccountId = this.node.tryGetContext('dev_account_id') || process.env.CDK_DEFAULT_ACCOUNT;
+    const deploymentRegion = this.node.tryGetContext('deployment_region') || process.env.CDK_DEFAULT_REGION;
   
     const demoStage = pipeline.addStage(new GameDemoFargatePipelineStage(this, "GameDemoPipelineStage", {
       env: { account: devAccountId, region: deploymentRegion }


### PR DESCRIPTION
## Summary
Make local/single-account `cdk deploy` work without hand-editing config, while preserving the cross-account pipeline behavior.

## Changes
- `lib/game-demo-pipeline-stack.ts`: fall back to `CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION` when context values are unset. No account ID is hardcoded — it's resolved at runtime from the active profile.
- `cdk.context.json`: remove the `"dev_account_id": "DevAccountId"` placeholder (it is truthy and would otherwise block the fallback).
- `README.md`: note that `dev_account_id` is optional for local single-account deploys and required for cross-account pipeline deploys.

## Behavior
- **Context set** (documented cross-account setup): unchanged — context wins.
- **Context unset** (local): account/region come from the active CLI profile.

## Testing
`cdk synth --profile <demo>` with no `--context` override now resolves to the active account and synthesizes cleanly (previously failed on the `DevAccountId` placeholder). Build green on TS 6.0.3. No account IDs are committed.